### PR TITLE
Precisamos de funcionalidade de criar SG

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -12,6 +12,7 @@ data "aws_ami" "ubuntu" {
 resource "aws_instance" "web" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
+  vpc_security_group_ids = var.enable_sg ? aws_security_group.optional[*].id : [data.aws_security_group.default.id]
 
   tags = {
     Name = var.name

--- a/sg.tf
+++ b/sg.tf
@@ -1,0 +1,41 @@
+data "aws_security_group" "default" {
+
+  filter {
+    name   = "group-name"
+    values = ["default"] 
+  }
+
+  tags = {
+    produto   = "default"
+  }
+}
+
+resource "aws_security_group" "optional" {
+  count = var.enable_sg ? 1 : 0
+  name        = "allow-traffic-${var.name}"
+
+  dynamic "ingress" {
+    iterator = port
+    for_each = var.ingress_ports
+    content {
+      from_port   = port.value
+      to_port     = port.value
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}

--- a/variable.tf
+++ b/variable.tf
@@ -6,3 +6,15 @@ variable "name" {
   type        = string
   description = "Name of product"
 }
+
+variable "enable_sg" {
+  type        = bool
+  default     = false
+  description = "Habilitar funcionalidade de criação do SG"
+}
+
+variable "ingress_ports" {
+  type        = list(number)
+  default     = []
+  description = "Lista de portas a serem liberadas"
+}


### PR DESCRIPTION
Criando SG com condição e bloco dinâmico para portas servidas pelo terrafile

Como testar:

Seu terrafile precisa ter esse conteúdo:

```
module "produto" {
  source                  = "git@github.com:gomex/terraform-module?ref=adicionar_feature_sg"
  name                    = "produto"
  enable_sg               = true
  ingress_ports           = [80,443]
}
```

```
make terraform-init
make terraform-plan
make terraform-apply
```

Deve esperar criação de security group com as portas informadas